### PR TITLE
Version Catalog support

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="16">
+    <bytecodeTargetLevel target="11">
       <module name="TrainingApp.app" target="18" />
     </bytecodeTargetLevel>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,13 +8,14 @@ plugins {
 
 android {
     compileSdk 33
+    buildToolsVersion '33.0.0'
 
     defaultConfig {
         applicationId "com.neudesic.myapplication"
         minSdk 21
         targetSdk 33
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -29,29 +30,28 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_16
-        targetCompatibility JavaVersion.VERSION_16
+        sourceCompatibility libs.versions.java.get()
+        targetCompatibility libs.versions.java.get()
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_16
+        jvmTarget = libs.versions.java.get()
     }
     buildFeatures {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerExtensionVersion libs.versions.compose.get()
     }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
-    buildToolsVersion '33.0.0'
 }
 
 dependencies {
     def nav_version = "2.5.2"
-    def dagger_version = "2.43.2"
+    def dagger_version = libs.versions.daggerhilt.get()
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Dagger - Hilt
@@ -62,11 +62,11 @@ dependencies {
 
     // For instrumentation tests
     androidTestImplementation  "com.google.dagger:hilt-android-testing:$dagger_version"
-    androidTestAnnotationProcessor "com.google.dagger:hilt-compiler:$dagger_version"
+    kaptAndroidTest "com.google.dagger:hilt-compiler:$dagger_version"
 
     // For local unit tests
     testImplementation "com.google.dagger:hilt-android-testing:$dagger_version"
-    testAnnotationProcessor "com.google.dagger:hilt-compiler:$dagger_version"
+    kaptTest "com.google.dagger:hilt-compiler:$dagger_version"
 
     implementation "androidx.navigation:navigation-compose:$nav_version"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,11 +30,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility libs.versions.java.get()
-        targetCompatibility libs.versions.java.get()
+        sourceCompatibility libs.versions.jvm.get()
+        targetCompatibility libs.versions.jvm.get()
     }
     kotlinOptions {
-        jvmTarget = libs.versions.java.get()
+        jvmTarget = libs.versions.jvm.get()
     }
     buildFeatures {
         compose true
@@ -52,43 +52,48 @@ android {
 dependencies {
     def nav_version = "2.5.2"
     def dagger_version = libs.versions.daggerhilt.get()
+
+    // ----debug implementations----
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+
+    // ----implementations----
+    implementation "androidx.core:core-ktx:$kotlin_version"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation 'androidx.compose.material3:material3:1.0.0-alpha01'
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.activity:activity-compose:1.3.1'
+
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Dagger - Hilt
     implementation "com.google.dagger:hilt-android:$dagger_version"
     kapt "com.google.dagger:hilt-android-compiler:$dagger_version"
-    //hiltViewModel
+    // hiltViewModel support
     implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
-
-    // For instrumentation tests
-    androidTestImplementation  "com.google.dagger:hilt-android-testing:$dagger_version"
-    kaptAndroidTest "com.google.dagger:hilt-compiler:$dagger_version"
-
-    // For local unit tests
-    testImplementation "com.google.dagger:hilt-android-testing:$dagger_version"
-    kaptTest "com.google.dagger:hilt-compiler:$dagger_version"
 
     implementation "androidx.navigation:navigation-compose:$nav_version"
 
     // for observeAsState
     implementation "androidx.compose.runtime:runtime-livedata:1.2.1"
 
-    // local Modules
-    implementation project(':module:core:network')
-
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.0.0-alpha01'
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "com.google.truth:truth:1.1.3"
+    // ----instrumentation tests----
+    androidTestImplementation  "com.google.dagger:hilt-android-testing:$dagger_version"
+    kaptAndroidTest "com.google.dagger:hilt-compiler:$dagger_version"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+
+    // ----local unit tests----
+    testImplementation "com.google.dagger:hilt-android-testing:$dagger_version"
+    kaptTest "com.google.dagger:hilt-compiler:$dagger_version"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "com.google.truth:truth:1.1.3"
+
+    // ----local Modules----
+    implementation project(':module:core:network')
+
 }
 
 kapt {

--- a/app/src/main/java/com/neudesic/myapplication/ui/navigation/MainNavigationGraph.kt
+++ b/app/src/main/java/com/neudesic/myapplication/ui/navigation/MainNavigationGraph.kt
@@ -32,6 +32,8 @@ fun MainNavigationGraph(navController: NavHostController) {
         composable(Screen.Home.route) {
             // ref: https://developer.android.com/training/dependency-injection/hilt-jetpack#viewmodel-navigation
             /**
+             * .....
+             * val dadJokeAPIService = ....
              *  val repository = DadJokeRepositoryImpl(dadJokeAPIService)
                 val useCase = GetDadJokesUseCase(repository)
                 val viewModel = HomeViewModel(useCase)

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,19 @@
 buildscript {
     ext {
-        compose_version = '1.2.0'
-        kotlin_version = '1.6.21'
+        compose_version = libs.versions.compose.get()
+        kotlin_version = libs.versions.kotlin.get()
     }
     repositories {
         mavenCentral()
     }
-    dependencies {
-        def dagger_version = "2.43.2"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+    dependencies {}
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.2.2' apply false
     id 'com.android.library' version '7.2.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.0' apply false
-    id 'com.google.dagger.hilt.android' version '2.43.2' apply false
+    id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.jvm' version "$kotlin_version" apply false
+    alias libs.plugins.dagger.hilt apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/README.md
+++ b/gradle/README.md
@@ -1,0 +1,7 @@
+# Version Catalog
+`libs.versions.toml` is used to manage shared dependencies. 
+
+If you find that you're adding a dependency that is required in other modules. You can use this file to share the versions instead of hardcoding it in multiple places
+
+## Reference
+- https://docs.gradle.org/7.5.1/userguide/platforms.html#sub:version-catalog-declaration:~:text=Gradle%20offers%20a%20conventional%20file%20to%20declare%20a%20catalog.%20If%20a%20libs.versions.toml%20file%20is%20found%20in%20the%20gradle%20subdirectory%20of%20the%20root%20build%2C%20then%20a%20catalog%20will%20be%20automatically%20declared%20with%20the%20contents%20of%20this%20file.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,24 @@
+# Version Catalog for our App
+
+# used to declare versions which can be referenced by dependencies
+# example usage: libs.versions.compose.get()
+[versions]
+kotlin = "1.7.0"
+java = "11"
+compose = "1.2.0"
+daggerhilt = "2.43.2"
+
+# this section is used to declare plugins
+# NOTE: when declaring aliases any of the -, _ and . characters can be used as separators, but the generated catalog will have all normalized to .
+# example usage: alias libs.plugins.dagger.hilt
+[plugins]
+dagger-hilt = {id = "com.google.dagger.hilt.android", version.ref = "daggerhilt"}
+
+# this section is used to declare the aliases to coordinates
+# used to alias dependencies under buildscript.dependencies {}
+[libraries]
+
+# this section is used to declare dependency bundles
+[bundles]
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 # example usage: libs.versions.compose.get()
 [versions]
 kotlin = "1.7.0"
-java = "11"
+jvm = "11"
 compose = "1.2.0"
 daggerhilt = "2.43.2"
 

--- a/module/core/network/build.gradle
+++ b/module/core/network/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = libs.versions.java.get()
-    targetCompatibility = libs.versions.java.get()
+    sourceCompatibility = libs.versions.jvm.get()
+    targetCompatibility = libs.versions.jvm.get()
 }
 
 dependencies {

--- a/module/core/network/build.gradle
+++ b/module/core/network/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = libs.versions.java.get()
+    targetCompatibility = libs.versions.java.get()
 }
 
 dependencies {


### PR DESCRIPTION
# Goal
Added support for Version Catalog. So we can share versions between modules.
In this case, we share JVM version between the App Module and Core Network Module.

See the [README](https://github.com/daniel112/Android-Training-App/blob/63521be482211e261525df4b317d29ede7813d48/gradle/README.md) and [Version Catalog](https://github.com/daniel112/Android-Training-App/blob/63521be482211e261525df4b317d29ede7813d48/gradle/libs.versions.toml) file for more details on how it works.

**NOTE**:
- I did not migrate all our dependencies into the Version Catalog as it is not really necessary atm. The data that exists in the file is for:
    - Example purposes
    - Actually is shared (JVM version)

## Update
- Add support for Version Catalog
- Fixed warning for DaggerHilt Kotlin testing dependencies

## References
- https://docs.gradle.org/current/userguide/platforms.html#sec:sharing-catalogs
- https://proandroiddev.com/using-version-catalog-on-android-projects-82d88d2f79e5 